### PR TITLE
server: use http.Error + skip fmt.Fprintf for rw writes

### DIFF
--- a/server/enroll.go
+++ b/server/enroll.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -35,11 +34,10 @@ func (c *context) Enroll(w http.ResponseWriter, r *http.Request) {
 	hostname := vars["hostname"]
 	cert, err := c.EnrollHost(hostname, r)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	fmt.Fprintf(w, cert)
+	w.Write([]byte(cert))
 }
 
 func (c *context) EnrollHost(hostname string, r *http.Request) (string, error) {

--- a/server/known_hosts.go
+++ b/server/known_hosts.go
@@ -18,18 +18,16 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 )
 
 func (c *context) KnownHosts(w http.ResponseWriter, r *http.Request) {
 	hosts, err := c.GetKnownHosts()
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	fmt.Fprintf(w, hosts)
+	w.Write([]byte(hosts))
 }
 
 func (c *context) GetKnownHosts() (string, error) {


### PR DESCRIPTION
+ Use http.Error when writing errors to http.ResponseWriter
instead of w.WriteHeader and then fmt.Fprintf.
+ Skip using fmt.Fprintf which is reflection expensive in favor
of w.Write([]byte(...))