### PR TITLE
Add RPM spec, systemd unit files, add example server and client configs into repo

### DIFF
--- a/examples/client.yml
+++ b/examples/client.yml
@@ -1,0 +1,21 @@
+# Server address
+request_addr: "https://sharkey-server.example:8080"
+
+# TLS config for making requests
+# ---
+tls:
+  ca: /path/to/ca-bundle.pem
+  cert: /path/to/client-certificate.pem 
+  key: /path/to/client-certificate-key.pem
+
+# OpenSSH host key (unsigned)
+host_key: /etc/ssh/ssh_host_rsa_key.pub
+
+# Where to install the signed host certificate
+signed_cert: /etc/ssh/ssh_host_rsa_key_signed.pub
+
+# Where to install the known_hosts file
+known_hosts: /etc/ssh/known_hosts
+
+# How often to refresh/request new certificate
+sleep: "24h"

--- a/examples/server.yml
+++ b/examples/server.yml
@@ -1,0 +1,41 @@
+# SQLite database
+# ---
+db:
+  address: /path/to/sharkey.db
+  type: sqlite
+
+# MySQL database
+# ---
+# db:
+#   username: root
+#   password: password
+#   address: hostname:port
+#   schema: ssh_ca
+#   type: mysql
+#   tls:                                       # MySQL TLS config (optional)
+#     ca: /path/to/mysql-ca-bundle.pem
+#     cert: /path/to/mysql-client-cert.pem     # MySQL client cert
+#     key: /path/to/mysql-client-cert-key.pem  # MySQL client cert key
+#     min_version: 1.2                         # Min. TLS version
+
+# Server listening address
+listen_addr: "0.0.0.0:8080"
+
+# TLS config for serving requests
+# ---
+tls:
+  ca: /path/to/ca-bundle.pem
+  cert: /path/to/server-certificate.pem 
+  key: /path/to/server-certificate-key.pem
+  min_version: 1.2                             # Min. TLS version (optional) 
+
+# Signing key (from ssh-keygen)
+signing_key: /path/to/ca-signing-key 
+
+# Lifetime/validity duration for generated host certificates
+cert_duration: 168h
+
+# Optional suffix to strip from client hostnames when generating certificates.
+# This is useful if all your machines have a common TLD/domain that you don't
+# want to include in generated certificates. Leave empty to disable.
+strip_suffix: ".squareup.com"

--- a/examples/server.yml
+++ b/examples/server.yml
@@ -38,4 +38,4 @@ cert_duration: 168h
 # Optional suffix to strip from client hostnames when generating certificates.
 # This is useful if all your machines have a common TLD/domain that you don't
 # want to include in generated certificates. Leave empty to disable.
-strip_suffix: ".squareup.com"
+strip_suffix: ".example.com"

--- a/rpm/build_rpm.sh
+++ b/rpm/build_rpm.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 DIR=$(dirname $(readlink -f $0))
 
-rev=$(git show-ref -s HEAD)
+rev=$(git rev-parse HEAD)
 
 tar -C "${DIR}/../.." -zcf ~/rpmbuild/SOURCES/sharkey-${rev}.tar.gz --transform s/sharkey/sharkey-${rev}/ sharkey
 rpmbuild -ba ${DIR}/sharkey.spec

--- a/rpm/build_rpm.sh
+++ b/rpm/build_rpm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR=$(dirname $(readlink -f $0))
+
+rev=$(git show-ref -s HEAD)
+
+tar -C "${DIR}/../.." -zcf ~/rpmbuild/SOURCES/sharkey-${rev}.tar.gz --transform s/sharkey/sharkey-${rev}/ sharkey
+rpmbuild -ba ${DIR}/sharkey.spec

--- a/rpm/sharkey-client.service
+++ b/rpm/sharkey-client.service
@@ -5,7 +5,7 @@ Description=Sharkey Client
 EnvironmentFile=/etc/sysconfig/sharkey-client
 ExecStart=/usr/sbin/sharkey-client --config=${SHARKEY_CONFIG}
 Restart=on-failure
-User=sharkey
+User=sharkey-client
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/sharkey-client.service
+++ b/rpm/sharkey-client.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sharkey Client
+
+[Service]
+EnvironmentFile=/etc/sysconfig/sharkey-client
+ExecStart=/usr/sbin/sharkey-client --config=${SHARKEY_CONFIG}
+Restart=on-failure
+User=sharkey
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/sharkey-client.sysconfig
+++ b/rpm/sharkey-client.sysconfig
@@ -1,0 +1,1 @@
+SHARKEY_CONFIG=/etc/sharkey/client.yml

--- a/rpm/sharkey-server.service
+++ b/rpm/sharkey-server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sharkey Server
+
+[Service]
+EnvironmentFile=/etc/sysconfig/sharkey-server
+ExecStartPre=/usr/sbin/sharkey-server --config=${SHARKEY_CONFIG} migrate --migrations=${SHARKEY_MIGRATIONS}
+ExecStart=/usr/sbin/sharkey-server --config=${SHARKEY_CONFIG} start
+Restart=on-failure
+User=sharkey
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/sharkey-server.sysconfig
+++ b/rpm/sharkey-server.sysconfig
@@ -1,0 +1,3 @@
+SHARKEY_CONFIG=/etc/sharkey/server.yml
+SHARKEY_MIGRATIONS=/etc/sharkey/db/sqlite
+#SHARKEY_MIGRATIONS=/etc/sharkey/db/mysql

--- a/rpm/sharkey.spec
+++ b/rpm/sharkey.spec
@@ -3,16 +3,15 @@
 %global _dwz_low_mem_die_limit 0
 %define function gobuild { go build -a -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "$@"; }
 
-Name:		sharkey
+Name:       sharkey
 Version:    0
-Release:    0.0.git%{shortrev}%{?dist}
-License:	Apache
-Summary:	Sharkey is a service for managing certificates for use by OpenSSH
-Url:		https://github.com/square/sharkey
-Group:		System/Security
-Source0:	https://github.com/square/%{name}/archive/%{rev}.tar.gz#/%{name}-%{rev}.tar.gz
-Requires:	openssh
-Requires(pre): shadow-utils
+Release:    0.1.git%{shortrev}%{?dist}
+License:    ASL 2.0
+Summary:    Sharkey is a service for managing certificates for use by OpenSSH
+Url:        https://github.com/square/sharkey
+Source0:    https://github.com/square/%{name}/archive/%{rev}.tar.gz#/%{name}-%{rev}.tar.gz
+Requires:   openssh
+Requires(pre):  shadow-utils
 
 # e.g. el6 has ppc64 arch without gcc-go, so EA tag is required
 ExclusiveArch:  %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 %{arm}}
@@ -23,16 +22,16 @@ BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
 Sharkey is a service for managing certificates for use by OpenSSH.
 
 %package server
-Summary:	Sharkey is a service for managing certificates for use by OpenSSH.
+Summary:    Sharkey is a service for managing certificates for use by OpenSSH.
 Version:    %{version}
-Group:      System/Security
+Group:      System Environment/Daemons
 %description server
 Sharkey-server is the server component to the Sharkey service for managing certificates for use by OpenSSH
 
 %package client
 Summary:    Sharkey is a service for managing certificates for use by OpenSSH.
 Version:    %{version}
-Group:      System/Security
+Group:      System Environment/Daemons
 %description client
 Sharkey-client is the client component to the Sharkey service for managing certificates for use by OpenSSH
 
@@ -124,6 +123,6 @@ rm -rf %{buildroot}
 %{_sysconfdir}/%{name}/client.yml.example
 
 %changelog
-* Wed Aug 01 2016 Ben Allen <bsallen@alcf.anl.gov> 
-- Initial release
+* Tue Aug 02 2016 Ben Allen <bsallen@alcf.anl.gov> - 0-0.1.gita6ec80f356d3
+- Initial RPM release
 

--- a/rpm/sharkey.spec
+++ b/rpm/sharkey.spec
@@ -1,0 +1,126 @@
+%global rev             %(git show-ref -s HEAD)
+%global shortrev        %(r=%{rev}; echo ${r:0:12})
+%global _dwz_low_mem_die_limit 0
+%define function gobuild { go build -a -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "$@"; }
+
+Name:		sharkey
+Version:    0
+Release:    0.0.git%{shortrev}%{?dist}
+License:	Apache
+Summary:	Sharkey is a service for managing certificates for use by OpenSSH
+Url:		https://github.com/square/sharkey
+Group:		System/Security
+Source0:	https://github.com/square/%{name}/archive/%{rev}.tar.gz#/%{name}-%{rev}.tar.gz
+Requires:	openssh
+
+# e.g. el6 has ppc64 arch without gcc-go, so EA tag is required
+ExclusiveArch:  %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 %{arm}}
+# If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
+BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
+
+%description
+Sharkey is a service for managing certificates for use by OpenSSH.
+
+%package server
+Summary:	Sharkey is a service for managing certificates for use by OpenSSH.
+Version:    %{version}
+Group:      System/Security
+%description server
+Sharkey-server is the server component to the Sharkey service for managing certificates for use by OpenSSH
+
+%package client
+Summary:    Sharkey is a service for managing certificates for use by OpenSSH.
+Version:    %{version}
+Group:      System/Security
+%description client
+Sharkey-client is the client component to the Sharkey service for managing certificates for use by OpenSSH
+
+%prep
+%setup -q -n %{name}-%{rev}
+
+%build
+mkdir -p src/github.com/square
+ln -s ../../../ src/github.com/square/sharkey
+
+%install
+export GOPATH=$(pwd):%{gopath}
+# Server
+%gobuild -o %{buildroot}%{_sbindir}/sharkey-server github.com/square/sharkey/server
+
+install -d %{buildroot}%{_unitdir}
+install -m 0644 rpm/%{name}-server.service %{buildroot}%{_unitdir}/%{name}-server.service
+install -d %{buildroot}/%{_sysconfdir}/sysconfig
+install -m 0644 rpm/%{name}-server.sysconfig %{buildroot}/%{_sysconfdir}/sysconfig/%{name}-server
+install -d %{buildroot}%{_sysconfdir}/sharkey
+install -m 0644 examples/server.yml %{buildroot}%{_sysconfdir}/sharkey/server.yml.example
+cp -r db %{buildroot}%{_sysconfdir}/sharkey/
+
+# Client
+%gobuild -o %{buildroot}%{_sbindir}/sharkey-client github.com/square/sharkey/client
+install -m 0644 rpm/%{name}-client.service %{buildroot}%{_unitdir}/%{name}-client.service
+install -m 0644 rpm/%{name}-client.sysconfig %{buildroot}/%{_sysconfdir}/sysconfig/%{name}-client
+install -m 0644 examples/client.yml %{buildroot}%{_sysconfdir}/sharkey/client.yml.example
+
+%pre server
+if ! /usr/bin/getent passwd sharkey &>/dev/null
+then
+    useradd --system --shell /sbin/nologin --home-dir %{_sysconfdir}/sharkey --user-group --comment "Sharkey user" --no-create-home sharkey
+fi
+
+%pre client
+if ! /usr/bin/getent passwd sharkey &>/dev/null
+then
+    useradd --system --shell /sbin/nologin --home-dir %{_sysconfdir}/sharkey --user-group --comment "Sharkey user" --no-create-home sharkey
+fi
+
+%post server
+/usr/bin/systemctl daemon-reload >/dev/null 2>&1
+
+%post client
+/usr/bin/systemctl daemon-reload >/dev/null 2>&1
+
+%preun server
+if [ $1 -eq 0 ] ; then
+    /usr/bin/systemctl stop %{name}-server >/dev/null 2>&1
+    /usr/bin/systemctl disable %{name}-server >/dev/null 2>&1
+fi
+
+%preun client
+if [ $1 -eq 0 ] ; then
+    /usr/bin/systemctl stop %{name}-client >/dev/null 2>&1
+    /usr/bin/systemctl disable %{name}-client >/dev/null 2>&1
+fi
+
+%postun server
+if [ "$1" -ge "1" ] ; then
+   /usr/bin/systemctl try-restart %{name}-server >/dev/null 2>&1 || :
+fi
+
+%postun client
+if [ "$1" -ge "1" ] ; then
+   /usr/bin/systemctl try-restart %{name}-client >/dev/null 2>&1 || :
+fi
+
+%clean
+rm -rf %{buildroot}
+
+%files server
+%defattr(-,root,root,-)
+%{_sbindir}/%{name}-server
+%{_unitdir}/%{name}-server.service
+%config %{_sysconfdir}/sysconfig/%{name}-server
+%{_sysconfdir}/sharkey/server.yml.example
+%{_sysconfdir}/sharkey/db/mysql/migrations/*
+%{_sysconfdir}/sharkey/db/sqlite/migrations/*
+
+%files client
+%defattr(-,root,root,-)
+%{_sbindir}/%{name}-client
+%{_unitdir}/%{name}-client.service
+%config %{_sysconfdir}/sysconfig/%{name}-client
+%{_sysconfdir}/sharkey/client.yml.example
+
+%changelog
+* Wed Aug 01 2016 Ben Allen <bsallen@alcf.anl.gov> 
+- Initial release
+


### PR DESCRIPTION
Add RPM spec, systemd unit files, add example server and client configs into repo (from the README). This is tested on RHEL7. Followed https://fedoraproject.org/wiki/PackagingDrafts/Go.

Note RHEL7 doesn't appear to have Go RPMs by default, so one has to build them from Fedora SPEC files.

