### PR TITLE
Ping on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ Configuration (example):
     # How often to refresh/request new certificate
     sleep: "24h"
 
+    # Refresh/request new certificate on start
+    ping_on_start: true
+
 OpenSSH will have to be configured to read the signed host certificate (this is
 with the `HostCertificate` config option in `sshd_config`). If the signed host
 certificate is missing from disk, OpenSSH will fall back to TOFU with the

--- a/client/sharkey_client.go
+++ b/client/sharkey_client.go
@@ -47,6 +47,7 @@ type config struct {
 	SignedCert  string    `yaml:"signed_cert"`
 	KnownHosts  string    `yaml:"known_hosts"`
 	Sleep       string
+	PingOnStart bool
 }
 
 type context struct {
@@ -80,11 +81,13 @@ func main() {
 		log.Print("Generated http client")
 	}
 
-	if c.conf.Sleep == "" {
+	if c.conf.Sleep == "" || c.conf.PingOnStart {
 		log.Print("Pinging server")
 		c.enroll()
 		c.makeKnownHosts()
-	} else {
+	}
+
+	if c.conf.Sleep != "" {
 		sleep, err := time.ParseDuration(c.conf.Sleep)
 		if err != nil {
 			log.Fatalf("error parsing sleep duration: %s", err.Error())

--- a/client/sharkey_client.go
+++ b/client/sharkey_client.go
@@ -47,7 +47,7 @@ type config struct {
 	SignedCert  string    `yaml:"signed_cert"`
 	KnownHosts  string    `yaml:"known_hosts"`
 	Sleep       string
-	PingOnStart bool
+	PingOnStart bool `yaml:"ping_on_start"`
 }
 
 type context struct {


### PR DESCRIPTION
Add client config option to refresh/request new certificate on start and update ssh_known_hosts on start. Previously the application would wait until sleep duration before the first update unless sleep was undefined.