### PR TITLE
Always ping on start, don't wait until sleep duration

### DIFF
--- a/client/sharkey_client.go
+++ b/client/sharkey_client.go
@@ -84,7 +84,7 @@ func main() {
 	c.enroll()
 	c.makeKnownHosts()
 
-	if c.conf.Sleep == "" {
+	if c.conf.Sleep != "" {
 		sleep, err := time.ParseDuration(c.conf.Sleep)
 		if err != nil {
 			log.Fatalf("error parsing sleep duration: %s", err.Error())

--- a/client/sharkey_client.go
+++ b/client/sharkey_client.go
@@ -84,17 +84,18 @@ func main() {
 	c.enroll()
 	c.makeKnownHosts()
 
-	sleep, err := time.ParseDuration(c.conf.Sleep)
-	if err != nil {
-		log.Fatalf("error parsing sleep duration: %s", err.Error())
+	if c.conf.Sleep == "" {
+		sleep, err := time.ParseDuration(c.conf.Sleep)
+		if err != nil {
+			log.Fatalf("error parsing sleep duration: %s", err.Error())
+		}
+		ticker := time.NewTicker(sleep)
+		for range ticker.C {
+			log.Print("Pinging server")
+			c.enroll()
+			c.makeKnownHosts()
+		}
 	}
-	ticker := time.NewTicker(sleep)
-	for range ticker.C {
-		log.Print("Pinging server")
-		c.enroll()
-		c.makeKnownHosts()
-	}
-
 }
 
 func (c *context) enroll() {

--- a/client/sharkey_client.go
+++ b/client/sharkey_client.go
@@ -80,22 +80,21 @@ func main() {
 		log.Print("Generated http client")
 	}
 
-	if c.conf.Sleep == "" {
+	log.Print("Pinging server")
+	c.enroll()
+	c.makeKnownHosts()
+
+	sleep, err := time.ParseDuration(c.conf.Sleep)
+	if err != nil {
+		log.Fatalf("error parsing sleep duration: %s", err.Error())
+	}
+	ticker := time.NewTicker(sleep)
+	for range ticker.C {
 		log.Print("Pinging server")
 		c.enroll()
 		c.makeKnownHosts()
-	} else {
-		sleep, err := time.ParseDuration(c.conf.Sleep)
-		if err != nil {
-			log.Fatalf("error parsing sleep duration: %s", err.Error())
-		}
-		ticker := time.NewTicker(sleep)
-		for range ticker.C {
-			log.Print("Pinging server")
-			c.enroll()
-			c.makeKnownHosts()
-		}
 	}
+
 }
 
 func (c *context) enroll() {


### PR DESCRIPTION
Fix bug where client would wait until sleep duration before the first ping. Now client enrolls and update known_hosts on start.