### PR TITLE
Close rows when finished with them, fixes sqlite 'database is locked'

### DIFF
--- a/server/enroll.go
+++ b/server/enroll.go
@@ -72,6 +72,7 @@ func (c *context) EnrollHost(hostname string, r *http.Request) (string, error) {
 	if rows.Next() {
 		newHost = false
 	}
+	rows.Close()
 	if newHost {
 		_, err = c.db.Exec("INSERT INTO hostkeys(hostname, pubkey) VALUES(?,?)", hostname, encodedPubkey)
 		if err != nil {
@@ -96,6 +97,7 @@ func (c *context) EnrollHost(hostname string, r *http.Request) (string, error) {
 			return "", err
 		}
 	}
+	rows.Close()
 	signedCert, err := c.signHost(hostname, uint64(id), pubkey)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
With a very moderate client load (1 client, refreshing every 5 seconds), sqlite reports the database is locked:

```
Aug 01 23:18:07 localhost sharkey-client[10132]: 2016/08/01 23:18:07 Pinging server
Aug 01 23:18:12 localhost sharkey-client[10132]: 2016/08/01 23:18:12 error retrieving signed cert from server
Aug 01 23:18:12 localhost sharkey-client[10132]: 2016/08/01 23:18:12 database is locked
```

Closing the rows from the select statements fixes this.

Ben


