### PR TITLE
Strip extra newlines from pubkeys

### DIFF
--- a/server/enroll.go
+++ b/server/enroll.go
@@ -62,7 +62,7 @@ func (c *context) EnrollHost(hostname string, r *http.Request) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	encodedPubkey := string(data)
+	encodedPubkey := strings.TrimLeft(string(data), "\n")
 	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(data)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Strip extra newlines from pubkeys. Otherwise our known_hosts have double-newlines. 