### PR TITLE
Update TLS settings to support databases still on TLSv1.1

### DIFF
--- a/server/sharkey.go
+++ b/server/sharkey.go
@@ -282,12 +282,16 @@ func buildConfig(opts tlsConfig) (*tls.Config, error) {
 		RootCAs:    caBundle,
 		ClientCAs:  caBundle,
 		ClientAuth: tls.VerifyClientCertIfGiven,
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS11,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 		},
 		CurvePreferences: []tls.CurveID{
 			// P-256 has an ASM implementation, others do not (as of 2016-12-19).


### PR DESCRIPTION
Update TLS settings to support databases still on TLSv1.1, such as shipped with older RHEL.