### PR TITLE
Make sharkey errcheck clean

### DIFF
--- a/server/authority.go
+++ b/server/authority.go
@@ -28,6 +28,6 @@ func (c *context) Authority(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write([]byte("@cert-authority * "))
-	w.Write(ssh.MarshalAuthorizedKey(c.signer.PublicKey()))
+	_, _ = w.Write([]byte("@cert-authority * "))
+	_, _ = w.Write(ssh.MarshalAuthorizedKey(c.signer.PublicKey()))
 }

--- a/server/enroll.go
+++ b/server/enroll.go
@@ -55,7 +55,7 @@ func (c *context) Enroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write([]byte(cert))
+	_, _ = w.Write([]byte(cert))
 }
 
 func (c *context) EnrollHost(hostname string, r *http.Request) (string, error) {
@@ -144,6 +144,9 @@ func (c *context) signHost(hostname string, serial uint64, pubkey ssh.PublicKey)
 		ValidBefore:     (uint64)(endTime.Unix()),
 	}
 
-	template.SignCert(rand.Reader, c.signer)
+	err = template.SignCert(rand.Reader, c.signer)
+	if err != nil {
+		return nil, err
+	}
 	return &template, nil
 }

--- a/server/known_hosts.go
+++ b/server/known_hosts.go
@@ -32,7 +32,7 @@ func (c *context) KnownHosts(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Write([]byte(hosts))
+	_, _ = w.Write([]byte(hosts))
 }
 
 func (c *context) GetKnownHosts() (string, error) {

--- a/server/sharkey.go
+++ b/server/sharkey.go
@@ -213,7 +213,7 @@ func (c *context) Status(w http.ResponseWriter, r *http.Request) {
 	if !resp.Ok {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}
-	w.Write(out)
+	_, _ = w.Write(out)
 }
 
 func (c *config) getDB() (*sql.DB, error) {
@@ -256,7 +256,10 @@ func (c *config) getMySQL() (*sql.DB, error) {
 		if err != nil {
 			return nil, err
 		}
-		mysql.RegisterTLSConfig("sharkey", tlsConfig)
+		err = mysql.RegisterTLSConfig("sharkey", tlsConfig)
+		if err != nil {
+			return nil, err
+		}
 		url += "?tls=sharkey"
 	}
 


### PR DESCRIPTION
For writing http responses, we ignore errors, since they're most likely
from clients that have disconnected, etc.  None of our responses are very
expensive so it doesn't matter much.