### PR TITLE
Add extensions to the SSH user certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,25 @@ Configuration (example):
     extra_known_hosts:
       - "@cert-authority *.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBwhA8rKPESjDy4iqTlkBqUlBU2xjwtmFUHY6cutA9TYbB5H/mjxzUpnSNw/HyFWNpysjTSQtHWWBdJdJGU/0aDgFUwbduHeDFxviGVSkOxm2AYn7XJopzITZRqmAmsYXHUBa75RQb+UgIG7EpCoi8hF4ItJV+TT777j1irkXwlMmeDiJEaA+7bPNdUdGw8zRbk0CyeotYVD0griRtkXdfgnQAu+DvBwOuW/uiZaPz/rAVjt4b9fmp6pcFKI3RsBqqn5tQVhKCPVuSwqvIQ7CTVkMClYovlH1/zGe8PG1DHbM9irP98S5j3mVD9W5v3QILpsg24RIS14M8pLarlD6t root@authority"
 
+    # User certs are issued to users who connect through an authenticating proxy
+    # That user should connect with a user certificate and set the username
+    # in a header.
+    auth_proxy:
+      # Hostname is validated against the incoming user certificate
+      hostname: proxy.example.com
+      # The HTTP header containing the username
+      username_header: X-Forwarded-User
+
+    # Optional settings related to SSH
+    ssh:
+      # List of extensions that should be set on the user certificate (default is no extensions)
+      user_cert_extensions:
+        - "permit-X11-forwarding"
+        - "permit-agent-forwarding"
+        - "permit-port-forwarding"
+        - "permit-pty"
+        - "permit-user-rc"
+
 A signing key for generating host certificates can be generated with `ssh-keygen`.
 
 #### Database

--- a/examples/server.yml
+++ b/examples/server.yml
@@ -58,11 +58,21 @@ extra_known_hosts:
   - "@cert-authority *.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBwhA8rKPESjDy4iqTlkBqUlBU2xjwtmFUHY6cutA9TYbB5H/mjxzUpnSNw/HyFWNpysjTSQtHWWBdJdJGU/0aDgFUwbduHeDFxviGVSkOxm2AYn7XJopzITZRqmAmsYXHUBa75RQb+UgIG7EpCoi8hF4ItJV+TT777j1irkXwlMmeDiJEaA+7bPNdUdGw8zRbk0CyeotYVD0griRtkXdfgnQAu+DvBwOuW/uiZaPz/rAVjt4b9fmp6pcFKI3RsBqqn5tQVhKCPVuSwqvIQ7CTVkMClYovlH1/zGe8PG1DHbM9irP98S5j3mVD9W5v3QILpsg24RIS14M8pLarlD6t root@authority"
 
 
-# Client certs are issued to users who connect through an authenticating proxy
-# That client should connect with a client certificate and set the username
+# User certs are issued to users who connect through an authenticating proxy
+# That user should connect with a user certificate and set the username
 # in a header.
 auth_proxy:
-  # Hostname is validated against the incoming client certificate
+  # Hostname is validated against the incoming user certificate
   hostname: proxy.example.com
   # The HTTP header containing the username
   username_header: X-Forwarded-User
+
+# Optional settings related to SSH
+ssh:
+  # List of extensions that should be set on the user certificate (default is no extensions)
+  user_cert_extensions:
+    - "permit-X11-forwarding"
+    - "permit-agent-forwarding"
+    - "permit-port-forwarding"
+    - "permit-pty"
+    - "permit-user-rc"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -32,6 +32,11 @@ type Config struct {
 	Aliases             map[string][]string  `yaml:"aliases"`
 	ExtraKnownHosts     []string             `yaml:"extra_known_hosts"`
 	AuthenticatingProxy *AuthenticatingProxy `yaml:"auth_proxy"`
+	SSH                 SSH                  `yaml:"ssh"`
+}
+
+type SSH struct {
+	UserCertExtensions []string `yaml:"user_cert_extensions"`
 }
 
 type TLS struct {

--- a/server/enroll.go
+++ b/server/enroll.go
@@ -144,6 +144,7 @@ func (c *context) sign(keyId string, principals []string, serial uint64, certTyp
 		ValidPrincipals: principals,
 		ValidAfter:      (uint64)(startTime.Unix()),
 		ValidBefore:     (uint64)(endTime.Unix()),
+		Permissions:     getPermissionsForCertType(&c.conf.SSH, certType),
 	}
 
 	err = template.SignCert(rand.Reader, c.signer)
@@ -233,4 +234,15 @@ func getDurationForCertType(cfg *config.Config, certType uint32) (time.Duration,
 	}
 
 	return duration, err
+}
+
+func getPermissionsForCertType(cfg *config.SSH, certType uint32) (perms ssh.Permissions) {
+	if certType == ssh.UserCert && len(cfg.UserCertExtensions) > 0 {
+		perms.Extensions = make(map[string]string, len(cfg.UserCertExtensions))
+		for _, ext := range cfg.UserCertExtensions {
+			perms.Extensions[ext] = ""
+		}
+		perms.Extensions = map[string]string{}
+	}
+	return
 }

--- a/test/integration/server_config.yaml
+++ b/test/integration/server_config.yaml
@@ -16,3 +16,10 @@ aliases:
 auth_proxy:
   hostname: proxy
   username_header: X-Forwarded-User
+ssh:
+  user_cert_extensions:
+    - "permit-X11-forwarding"
+    - "permit-agent-forwarding"
+    - "permit-port-forwarding"
+    - "permit-pty"
+    - "permit-user-rc"

--- a/test/server_config.yaml
+++ b/test/server_config.yaml
@@ -10,7 +10,13 @@ signing_key: test/keys/server_ca
 host_cert_duration: 168h
 user_cert_duration: 24h
 listen_addr: "127.0.0.1:8080"
-
 auth_proxy:
   hostname: proxy.example.com
   username_header: X-Forwarded-User
+ssh:
+  user_cert_extensions:
+    - "permit-X11-forwarding"
+    - "permit-agent-forwarding"
+    - "permit-port-forwarding"
+    - "permit-pty"
+    - "permit-user-rc"


### PR DESCRIPTION
Currently, user certificates signed by sharkey did not have any
extensions, while the certs signed by ssh-keygen, by default get:

    Extensions:
        permit-X11-forwarding
        permit-agent-forwarding
        permit-port-forwarding
        permit-pty

This change ensures that sharkey matches the behavior of ssh-keygen.

I've pulled this from #84, since we definitely need this (unlike the API change).