### PR TITLE
put signing code into common pkg

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -51,9 +52,11 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.5.0 h1:4wjo3sf9azi99c8hTmyaxp9y5S+pFszsy3pP0rAw/lw=
 github.com/gorilla/handlers v1.5.0/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/pkg/common/sign/sign.go
+++ b/pkg/common/sign/sign.go
@@ -1,0 +1,108 @@
+package sign
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/square/sharkey/pkg/server/config"
+	"github.com/square/sharkey/pkg/server/storage"
+	"golang.org/x/crypto/ssh"
+)
+
+type Signer struct {
+	signer  ssh.Signer
+	conf    *config.Config
+	storage storage.Storage
+}
+
+func NewSigner(signer ssh.Signer, conf *config.Config, storage storage.Storage) Signer {
+	return Signer{
+		signer:  signer,
+		conf:    conf,
+		storage: storage,
+	}
+}
+
+func (s *Signer) Sign(keyId string, principals []string, certType uint32, pubkey ssh.PublicKey, extensions map[string]string) (*ssh.Certificate, error) {
+	serial, err := s.storage.RecordIssuance(certType, keyId, pubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, 32)
+	_, err = rand.Read(nonce)
+	if err != nil {
+		return nil, err
+	}
+	startTime := time.Now()
+	duration, err := getDurationForCertType(s.conf, certType)
+	if err != nil {
+		return nil, err
+	}
+	endTime := startTime.Add(duration)
+	template := ssh.Certificate{
+		Nonce:           nonce,
+		Key:             pubkey,
+		Serial:          serial,
+		CertType:        certType,
+		KeyId:           keyId,
+		ValidPrincipals: principals,
+		ValidAfter:      (uint64)(startTime.Unix()),
+		ValidBefore:     (uint64)(endTime.Unix()),
+		Permissions:     getPermissionsForCertType(&s.conf.SSH, certType),
+	}
+
+	if template.Extensions == nil {
+		template.Extensions = extensions
+	} else {
+		for key, val := range extensions {
+			template.Extensions[key] = val
+		}
+	}
+
+	err = template.SignCert(rand.Reader, s.signer)
+	if err != nil {
+		return nil, err
+	}
+	return &template, nil
+}
+
+func (s *Signer) PublicKey() ssh.PublicKey {
+	return s.signer.PublicKey()
+}
+
+func getPermissionsForCertType(cfg *config.SSH, certType uint32) (perms ssh.Permissions) {
+	switch certType {
+	case ssh.UserCert:
+		if cfg != nil && len(cfg.UserCertExtensions) > 0 {
+			perms.Extensions = make(map[string]string, len(cfg.UserCertExtensions))
+			for _, ext := range cfg.UserCertExtensions {
+				perms.Extensions[ext] = ""
+			}
+		}
+	}
+	return
+}
+
+func getDurationForCertType(cfg *config.Config, certType uint32) (time.Duration, error) {
+	var duration time.Duration
+	var err error
+
+	switch certType {
+	case ssh.HostCert:
+		duration, err = time.ParseDuration(cfg.HostCertDuration)
+	case ssh.UserCert:
+		duration, err = time.ParseDuration(cfg.UserCertDuration)
+	default:
+		err = fmt.Errorf("unknown cert type %d", certType)
+	}
+
+	return duration, err
+}
+
+func EncodeCert(certificate *ssh.Certificate) (string, error) {
+	certString := base64.StdEncoding.EncodeToString(certificate.Marshal())
+	return fmt.Sprintf("%s-cert-v01@openssh.com %s\n", certificate.Key.Type(), certString), nil
+}

--- a/pkg/server/api/enroll.go
+++ b/pkg/server/api/enroll.go
@@ -17,19 +17,17 @@
 package api
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"time"
-
-	"github.com/square/sharkey/pkg/server/config"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+	"github.com/square/sharkey/pkg/common/sign"
+	"github.com/square/sharkey/pkg/server/config"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -78,29 +76,18 @@ func readPubkey(r *http.Request) (ssh.PublicKey, error) {
 	return pubkey, err
 }
 
-func encodeCert(certificate *ssh.Certificate) (string, error) {
-	certString := base64.StdEncoding.EncodeToString(certificate.Marshal())
-	return fmt.Sprintf("%s-cert-v01@openssh.com %s\n", certificate.Key.Type(), certString), nil
-}
-
 func (c *Api) EnrollHost(hostname string, r *http.Request) (string, error) {
 	pubkey, err := readPubkey(r)
 	if err != nil {
 		return "", err
 	}
 
-	// Update table with host
-	id, err := c.storage.RecordIssuance(ssh.HostCert, hostname, pubkey)
+	signedCert, err := c.signHost(hostname, pubkey)
 	if err != nil {
 		return "", err
 	}
 
-	signedCert, err := c.signHost(hostname, id, pubkey)
-	if err != nil {
-		return "", err
-	}
-
-	return encodeCert(signedCert)
+	return sign.EncodeCert(signedCert)
 }
 
 func clientAuthenticated(r *http.Request) bool {
@@ -116,7 +103,7 @@ func clientHostnameMatches(hostname string, r *http.Request) bool {
 	return cert.VerifyHostname(hostname) == nil
 }
 
-func (c *Api) signHost(hostname string, serial uint64, pubkey ssh.PublicKey) (*ssh.Certificate, error) {
+func (c *Api) signHost(hostname string, pubkey ssh.PublicKey) (*ssh.Certificate, error) {
 	principals := []string{hostname}
 	if c.conf.StripSuffix != "" && strings.HasSuffix(hostname, c.conf.StripSuffix) {
 		principals = append(principals, strings.TrimSuffix(hostname, c.conf.StripSuffix))
@@ -124,51 +111,8 @@ func (c *Api) signHost(hostname string, serial uint64, pubkey ssh.PublicKey) (*s
 	if aliases, ok := c.conf.Aliases[hostname]; ok {
 		principals = append(principals, aliases...)
 	}
-	return c.sign(hostname, principals, serial, ssh.HostCert, pubkey)
-}
 
-func (c *Api) sign(keyId string, principals []string, serial uint64, certType uint32, pubkey ssh.PublicKey) (*ssh.Certificate, error) {
-	nonce := make([]byte, 32)
-	_, err := rand.Read(nonce)
-	if err != nil {
-		return nil, err
-	}
-	startTime := time.Now()
-	duration, err := getDurationForCertType(c.conf, certType)
-	if err != nil {
-		return nil, err
-	}
-	endTime := startTime.Add(duration)
-	template := ssh.Certificate{
-		Nonce:           nonce,
-		Key:             pubkey,
-		Serial:          serial,
-		CertType:        certType,
-		KeyId:           keyId,
-		ValidPrincipals: principals,
-		ValidAfter:      (uint64)(startTime.Unix()),
-		ValidBefore:     (uint64)(endTime.Unix()),
-		Permissions:     getPermissionsForCertType(&c.conf.SSH, certType),
-	}
-
-	if c.conf.GitHub.IncludeUserIdentity {
-		username, err := c.RetrieveGitHubUsername(keyId)
-		if err != nil {
-			c.logger.Error(err)
-		} else if username != "" {
-			// If no error in retrieval and username not empty string then add github extension
-			if template.Extensions == nil {
-				template.Extensions = map[string]string{}
-			}
-			template.Extensions["login@github.com"] = username
-		}
-	}
-
-	err = template.SignCert(rand.Reader, c.signer)
-	if err != nil {
-		return nil, err
-	}
-	return &template, nil
+	return c.signer.Sign(hostname, principals, ssh.HostCert, pubkey, map[string]string{})
 }
 
 // This assumes there's an authenticating proxy which provides the user in a header, configurable.
@@ -208,19 +152,24 @@ func (c *Api) EnrollUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := c.storage.RecordIssuance(ssh.UserCert, user, pk)
+	extensions := map[string]string{}
+	if c.conf.GitHub.IncludeUserIdentity {
+		username, err := c.RetrieveGitHubUsername(user)
+		if err != nil {
+			c.logger.Error(err)
+		} else if username != "" {
+			// If no error in retrieval and username not empty string then add github extension
+			extensions["login@github.com"] = username
+		}
+	}
+
+	certificate, err := c.signer.Sign(user, []string{user}, ssh.UserCert, pk, extensions)
 	if err != nil {
 		logHttpError(r, w, err, http.StatusInternalServerError, c.logger)
 		return
 	}
 
-	certificate, err := c.sign(user, []string{user}, id, ssh.UserCert, pk)
-	if err != nil {
-		logHttpError(r, w, err, http.StatusInternalServerError, c.logger)
-		return
-	}
-
-	certString, err := encodeCert(certificate)
+	certString, err := sign.EncodeCert(certificate)
 	if err != nil {
 		logHttpError(r, w, err, http.StatusInternalServerError, c.logger)
 		return
@@ -234,33 +183,4 @@ func (c *Api) EnrollUser(w http.ResponseWriter, r *http.Request) {
 		"Public Key": encodedPublicKey,
 		"user":       user,
 	}).Println("call EnrollUser")
-}
-
-func getDurationForCertType(cfg *config.Config, certType uint32) (time.Duration, error) {
-	var duration time.Duration
-	var err error
-
-	switch certType {
-	case ssh.HostCert:
-		duration, err = time.ParseDuration(cfg.HostCertDuration)
-	case ssh.UserCert:
-		duration, err = time.ParseDuration(cfg.UserCertDuration)
-	default:
-		err = fmt.Errorf("unknown cert type %d", certType)
-	}
-
-	return duration, err
-}
-
-func getPermissionsForCertType(cfg *config.SSH, certType uint32) (perms ssh.Permissions) {
-	switch certType {
-	case ssh.UserCert:
-		if cfg != nil && len(cfg.UserCertExtensions) > 0 {
-			perms.Extensions = make(map[string]string, len(cfg.UserCertExtensions))
-			for _, ext := range cfg.UserCertExtensions {
-				perms.Extensions[ext] = ""
-			}
-		}
-	}
-	return
 }

--- a/pkg/server/api/enroll.go
+++ b/pkg/server/api/enroll.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
-	"github.com/square/sharkey/pkg/common/sign"
+	"github.com/square/sharkey/pkg/server/cert"
 	"github.com/square/sharkey/pkg/server/config"
 	"golang.org/x/crypto/ssh"
 )
@@ -87,7 +87,7 @@ func (c *Api) EnrollHost(hostname string, r *http.Request) (string, error) {
 		return "", err
 	}
 
-	return sign.EncodeCert(signedCert)
+	return cert.EncodeCert(signedCert)
 }
 
 func clientAuthenticated(r *http.Request) bool {
@@ -169,7 +169,7 @@ func (c *Api) EnrollUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	certString, err := sign.EncodeCert(certificate)
+	certString, err := cert.EncodeCert(certificate)
 	if err != nil {
 		logHttpError(r, w, err, http.StatusInternalServerError, c.logger)
 		return

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -32,7 +32,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/square/sharkey/pkg/common/sign"
+	"github.com/square/sharkey/pkg/server/cert"
 	"github.com/square/sharkey/pkg/server/config"
 	"github.com/square/sharkey/pkg/server/storage"
 	"github.com/stretchr/testify/assert"
@@ -308,7 +308,7 @@ func generateContext(t *testing.T) (*Api, error) {
 	sshSigner, err := ssh.ParsePrivateKey(key)
 	require.NoError(t, err)
 
-	signer := sign.NewSigner(sshSigner, conf, sqlite)
+	signer := cert.NewSigner(sshSigner, conf, sqlite)
 
 	c := &Api{
 		signer:  signer,

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/square/sharkey/pkg/common/sign"
 	"github.com/square/sharkey/pkg/server/config"
 	"github.com/square/sharkey/pkg/server/storage"
 	"github.com/stretchr/testify/assert"
@@ -70,9 +71,9 @@ func TestSignHost(t *testing.T) {
 	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(data)
 	require.NoError(t, err)
 
-	cert, err := c.signHost("hostname.square", 42, pubkey)
+	cert, err := c.signHost("hostname.square", pubkey)
 	require.NoError(t, err, "SignHost method returned an error")
-	require.Equal(t, uint64(42), cert.Serial, "Incorrect cert serial number")
+	require.Equal(t, uint64(1), cert.Serial, "Incorrect cert serial number")
 	require.Equal(t, "hostname.square", cert.KeyId, "Cert pubkey doesn't match")
 	require.Equal(t, pubkey, cert.Key, "Cert pubkey doesn't match")
 	require.Contains(t, cert.ValidPrincipals, "hostname.square")
@@ -296,9 +297,6 @@ func generateContext(t *testing.T) (*Api, error) {
 	key, err := ioutil.ReadFile(conf.SigningKey)
 	require.NoError(t, err)
 
-	signer, err := ssh.ParsePrivateKey(key)
-	require.NoError(t, err)
-
 	logger := logrus.New()
 
 	// in-memory sqlite: see https://github.com/mattn/go-sqlite3 for address docs
@@ -306,6 +304,11 @@ func generateContext(t *testing.T) (*Api, error) {
 	require.NoError(t, err)
 	err = sqlite.Migrate("../../../db/sqlite/migrations")
 	require.NoError(t, err)
+
+	sshSigner, err := ssh.ParsePrivateKey(key)
+	require.NoError(t, err)
+
+	signer := sign.NewSigner(sshSigner, conf, sqlite)
 
 	c := &Api{
 		signer:  signer,

--- a/pkg/server/api/sharkey.go
+++ b/pkg/server/api/sharkey.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/square/sharkey/pkg/common/sign"
+	"github.com/square/sharkey/pkg/server/cert"
 	"io/ioutil"
 	"net/http"
 
@@ -41,7 +41,7 @@ type statusResponse struct {
 }
 
 type Api struct {
-	signer       sign.Signer
+	signer       *cert.Signer
 	storage      storage.Storage
 	conf         *config.Config
 	logger       *logrus.Logger
@@ -67,7 +67,7 @@ func Run(conf *config.Config, logger *logrus.Logger) {
 		logger.WithError(err).Fatal("unable to parse signing key data")
 	}
 
-	signer := sign.NewSigner(sshSigner, conf, storage)
+	signer := cert.NewSigner(sshSigner, conf, storage)
 
 	c := Api{
 		conf:    conf,

--- a/pkg/server/cert/cert.go
+++ b/pkg/server/cert/cert.go
@@ -1,4 +1,4 @@
-package sign
+package cert
 
 import (
 	"crypto/rand"
@@ -17,8 +17,8 @@ type Signer struct {
 	storage storage.Storage
 }
 
-func NewSigner(signer ssh.Signer, conf *config.Config, storage storage.Storage) Signer {
-	return Signer{
+func NewSigner(signer ssh.Signer, conf *config.Config, storage storage.Storage) *Signer {
+	return &Signer{
 		signer:  signer,
 		conf:    conf,
 		storage: storage,


### PR DESCRIPTION
move cert signing code into the common library section

- Create new Signer struct that encapsulates ssh.Signer
- Remove sign method from Api struct
- signHost and enrollUser in Api struct directly call Signer
- Signer struct handles recording into database