### PR TITLE
always need to declare a metrics sink

### DIFF
--- a/pkg/server/api/sharkey.go
+++ b/pkg/server/api/sharkey.go
@@ -76,13 +76,14 @@ func Run(conf *config.Config, logger *logrus.Logger) {
 		logger:  logger,
 	}
 
-	if c.conf.Telemetry.Address != "" {
-		telemetry, err := telemetry.CreateTelemetry(c.conf.Telemetry.Address)
-		if err != nil {
-			logger.WithError(err).Fatal("unable to setup telemetry")
-		}
-		c.telemetry = telemetry
+	if c.conf.Telemetry.Address == "" {
+		logger.Warn("Telemetry address not found, using blackhole metrics sink")
 	}
+	telemetryImpl, err := telemetry.CreateTelemetry(c.conf.Telemetry.Address)
+	if err != nil {
+		logger.WithError(err).Fatal("unable to setup telemetry")
+	}
+	c.telemetry = telemetryImpl
 
 	handler := mux.NewRouter()
 	handler.Path("/enroll/{hostname}").Methods("POST").HandlerFunc(c.Enroll)

--- a/pkg/server/telemetry/telemetry.go
+++ b/pkg/server/telemetry/telemetry.go
@@ -29,9 +29,15 @@ type Telemetry struct {
 }
 
 func CreateTelemetry(addr string) (*Telemetry, error) {
-	sink, err := datadog.NewDogStatsdSink(addr, "")
-	if err != nil {
-		return nil, err
+	var sink metrics.MetricSink
+	if addr == "" {
+		sink = &metrics.BlackholeSink{}
+	} else {
+		var err error
+		sink, err = datadog.NewDogStatsdSink(addr, "")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	metricsImpl, err := metrics.New(metrics.DefaultConfig(Service), sink)


### PR DESCRIPTION
We always need to declare a metrics sink because we always attempt to update metrics. This results in a null pointer exception if telemetry is not created. Therefore, we create a blackhole sink and warn if metrics are left undeclared in the config