### PR TITLE
add middleware to record http endpoint metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.1 // indirect
 	github.com/armon/go-metrics v0.3.4
 	github.com/bradleyfalzon/ghinstallation v1.1.1
+	github.com/felixge/httpsnoop v1.0.1
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/go-github/v29 v29.0.3 // indirect
 	github.com/gorilla/handlers v1.5.1
@@ -24,7 +25,7 @@ require (
 	github.com/ziutek/mymysql v0.0.0-20160623123511-8787d5581eb6 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
-	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YAR
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v1.5.0 h1:4wjo3sf9azi99c8hTmyaxp9y5S+pFszsy3pP0rAw/lw=
 github.com/gorilla/handlers v1.5.0/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/pkg/server/api/sharkey.go
+++ b/pkg/server/api/sharkey.go
@@ -85,7 +85,10 @@ func Run(conf *config.Config, logger *logrus.Logger) {
 	}
 	c.telemetry = telemetryImpl
 
+	metricsMiddlware := telemetry.NewMetricsMiddleware(c.telemetry)
+
 	handler := mux.NewRouter()
+	handler.Use(metricsMiddlware.InstrumentHTTPEndpointStats)
 	handler.Path("/enroll/{hostname}").Methods("POST").HandlerFunc(c.Enroll)
 	handler.Path("/enroll_user").Methods("POST").HandlerFunc(c.EnrollUser)
 	handler.Path("/known_hosts").Methods("GET").HandlerFunc(c.KnownHosts)

--- a/pkg/server/telemetry/middleware.go
+++ b/pkg/server/telemetry/middleware.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+type MetricsMiddleware struct {
+	telemetry *Telemetry
+}
+
+func NewMetricsMiddleware(t *Telemetry) *MetricsMiddleware {
+	return &MetricsMiddleware{t}
+}
+
+func (m *MetricsMiddleware) InstrumentHTTPEndpointStats(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		logger, w := makeMetricsResponseLogger(w)
+
+		route := mux.CurrentRoute(r)
+		path, err := route.GetPathTemplate()
+		if err != nil {
+			logrus.Warn("unable to retrieve path from route for metrics")
+		}
+
+		endpoint := m.parseRoute(path)
+
+		h.ServeHTTP(w, r)
+
+		if endpoint != "" {
+			m.telemetry.Metrics.IncrCounter([]string{endpoint, Count}, 1)
+			m.telemetry.Metrics.SetGauge([]string{endpoint, Latency}, float32(time.Since(start).Milliseconds()))
+			if logger.Status() >= 500 {
+				m.telemetry.Metrics.IncrCounter([]string{endpoint, "500"}, 1)
+			} else if logger.Status() >= 400 {
+				m.telemetry.Metrics.IncrCounter([]string{endpoint, "400"}, 1)
+			} else if logger.Status() >= 200 && logger.status < 300 {
+				m.telemetry.Metrics.IncrCounter([]string{endpoint, "200"}, 1)
+			}
+		}
+	})
+}
+
+func (m *MetricsMiddleware) parseRoute(routeName string) string {
+	switch routeName {
+	case "/enroll/{hostname}":
+		return "enroll_host"
+	default:
+		return strings.ReplaceAll(strings.Trim(routeName, "/"), "/", "_")
+	}
+}
+
+// metricsResponseLogger hooks onto an http ResponseWriter and tracks the http response code of that ResponseWriter
+// When the ResponseWriter writes the response code into the http header, we hook into that function and record
+// the response code
+type metricsResponseLogger struct {
+	w      http.ResponseWriter
+	status int
+}
+
+func (l *metricsResponseLogger) WriteHeader(code int) {
+	l.status = code
+}
+
+func (l *metricsResponseLogger) Status() int {
+	return l.status
+}
+
+func makeMetricsResponseLogger(w http.ResponseWriter) (*metricsResponseLogger, http.ResponseWriter) {
+	logger := &metricsResponseLogger{w: w, status: http.StatusOK}
+	return logger, httpsnoop.Wrap(w, httpsnoop.Hooks{
+		WriteHeader: func(httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return logger.WriteHeader
+		},
+	})
+}


### PR DESCRIPTION
record successes, client/server errors, latencies, and total number of requests for each Sharkey endpoint

As an example, these would be the metrics for the `/enroll/{hostname}' endpoint:

`sharkey.enroll_host.200`: successes

`sharkey.enroll_host.400`: client errors 

`sharkey.enroll_host.500`: server errors 

`sharkey.enroll_host.latency`: latency 

`sharkey.enroll_host.count`: total requests

