### PR TITLE
better sql handling

### DIFF
--- a/pkg/server/api/github.go
+++ b/pkg/server/api/github.go
@@ -3,9 +3,10 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/square/sharkey/pkg/server/telemetry"
 	"net/http"
 	"time"
+
+	"github.com/square/sharkey/pkg/server/telemetry"
 
 	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/robfig/cron/v3"


### PR DESCRIPTION
use replace for mysql, and delete sso_identities no longer being used

REPLACE: https://dev.mysql.com/doc/refman/8.0/en/replace.html
is a better alternative to INSERT with the DUPLICATE KEY clause. Since github_username is marked as UNIQUE it also counts as a DUPLICATE KEY. This meant that changes to sso_identity was not reflected in the DB as on duplicate github_username or duplicate sso_identity, only github_username was updated. REPLACE will delete conflicting rows and recreate them, ensuring that this case will be handled in the future.