### PR TITLE
Added idle connection closing to sharkey-client

### DIFF
--- a/pkg/client/sharkey_client.go
+++ b/pkg/client/sharkey_client.go
@@ -206,6 +206,10 @@ func (c *Client) makeKnownHosts() {
 }
 
 func (c *Client) GenerateClient() error {
+	if c.client != nil {
+		c.client.CloseIdleConnections()
+	}
+
 	tlsConfig, err := buildConfig(c.conf.TLS.Ca)
 	if err != nil {
 		return err

--- a/pkg/server/api/sharkey.go
+++ b/pkg/server/api/sharkey.go
@@ -18,9 +18,11 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/square/sharkey/pkg/server/cert"
 	"io/ioutil"
 	"net/http"
+	"time"
+
+	"github.com/square/sharkey/pkg/server/cert"
 
 	_ "bitbucket.org/liamstask/goose/lib/goose"
 	"github.com/gorilla/handlers"
@@ -100,9 +102,10 @@ func Run(conf *config.Config, logger *logrus.Logger) {
 		logger.WithError(err).Fatal("issue with BuildTLS")
 	}
 	server := &http.Server{
-		Addr:      conf.ListenAddr,
-		TLSConfig: tlsConfig,
-		Handler:   loggingHandler,
+		Addr:        conf.ListenAddr,
+		TLSConfig:   tlsConfig,
+		Handler:     loggingHandler,
+		IdleTimeout: time.Minute * 5,
 	}
 
 	if c.conf.GitHub.SyncEnabled {


### PR DESCRIPTION
Idle connections were being maintained by sharkey-client, occupying space on sharkey-server even after sharkey-client regenerated its http.client. This should fix the existing memory leaks on the server side.

I also added a five minute idle timeout to sharkey-server. Since client generation is guaranteed, this should clean up clients while preventing idle connections in the case of a misbehaving client.