### PR TITLE
Fixing bad service command path for ssh_reload during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Configuration (example):
 
     # Command to restart ssh daemon for the host
     # If sudo is set as well, this command will be prefixed with 'sudo'
-    ssh_reload: ["service", "ssh", "restart"]
+    ssh_reload: ["/usr/sbin/service", "ssh", "restart"]
 
 OpenSSH will have to be configured to read the signed host certificate (this is
 with the `HostCertificate` config option in `sshd_config`). If the signed host

--- a/examples/client.yml
+++ b/examples/client.yml
@@ -5,7 +5,7 @@ request_addr: "https://sharkey-server.example:8080"
 # ---
 tls:
   ca: /path/to/ca-bundle.pem
-  cert: /path/to/client-certificate.pem 
+  cert: /path/to/client-certificate.pem
   key: /path/to/client-certificate-key.pem
 
 # List of host keys for OpenSSH server
@@ -31,4 +31,4 @@ sudo: "/usr/bin/sudo"
 
 # Command to restart ssh
 # If sudo is set as well, this command will be prefixed with 'sudo'
-ssh_reload: ["service", "ssh", "restart"]
+ssh_reload: ["/usr/sbin/service", "ssh", "restart"]

--- a/test/client_config.yaml
+++ b/test/client_config.yaml
@@ -10,4 +10,4 @@ host_keys:
 known_hosts: test/ssh/known_hosts
 sleep: "2s"
 sudo: "/usr/bin/sudo"
-ssh_reload: ["service", "ssh", "restart"]
+ssh_reload: ["/usr/sbin/service", "ssh", "restart"]

--- a/test/integration/client_config.yaml
+++ b/test/integration/client_config.yaml
@@ -13,4 +13,4 @@ host_keys:
     signed: "/etc/ssh/ssh_host_ecdsa_key-cert.pub"
 known_hosts: /etc/ssh/known_hosts
 sleep: "10s"
-ssh_reload: ["service", "ssh", "restart"]
+ssh_reload: ["/usr/sbin/service", "ssh", "restart"]


### PR DESCRIPTION
When passing path into exec.Cmd it needs to be an absolute path in order for the `service` binary to run. 
* Changed all uses of `service` for `ssh_reload` to be `/usr/sbin/service` to address `time="2023-04-25T16:30:00Z" level=error msg="Failed to execute command" command="[service ssh restart]" error="fork/exec service: no such file or directory"`